### PR TITLE
Bump xms deps (xmscore 7.0.8, xmsgrid 9.0.9, xmsinterp 7.0.8, xmsconan 2.12.2) and add py3.10 Windows builds

### DIFF
--- a/.github/workflows/XmsExtractor-CI.yaml
+++ b/.github/workflows/XmsExtractor-CI.yaml
@@ -104,7 +104,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.6.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -230,7 +230,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan devpi-client wheel
-          pip install xmsconan>=2.6.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -322,12 +322,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-2022]
-        python-version: ['3.13']
+        python-version: ["3.10", "3.13"]
         compiler-version: [17]
         build_type: [Release, Debug]
 
     env:
-      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}
+      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}-py${{ matrix.python-version }}
       # Library Variables
       LIBRARY_NAME: xmsextractor
       XMS_VERSION: '0.0.0'
@@ -353,10 +353,10 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
       # Setup Python
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       # Setup Dev Command Prompt env for MSVC
       - name: Setup MSVC env
         uses: ilammy/msvc-dev-cmd@v1
@@ -367,7 +367,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.6.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2
@@ -414,7 +414,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ runner.os }}
+          name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
         if: matrix.build_type == 'Release'
       # Upload wheel to Aquapi

--- a/build.toml
+++ b/build.toml
@@ -3,9 +3,9 @@ description = "Extractor library for XMS products"
 ci_type = "github"
 
 xms_dependencies = [
-    { name = "xmscore", version = "7.0.7" },
-    { name = "xmsgrid", version = "9.0.8" },
-    { name = "xmsinterp", version = "7.0.7" },
+    { name = "xmscore", version = "7.0.8" },
+    { name = "xmsgrid", version = "9.0.9" },
+    { name = "xmsinterp", version = "7.0.8" },
 ]
 
 python_namespaced_dir = "extractor"
@@ -45,3 +45,6 @@ pybind_sources = [
 pybind_headers = [
     "xmsextractor/python/extractor/extractor_py.h"
 ]
+
+[ci]
+python_versions = ["3.10", "3.13"]


### PR DESCRIPTION
## Summary
- Bump xmscore to 7.0.8, xmsgrid to 9.0.9, xmsinterp to 7.0.8 in `build.toml`.
- Bump `xmsconan` requirement to `>=2.12.2` across the CI workflow.
- Add Python 3.10 to the Windows CI matrix (Mac/Linux remain on 3.13 — no `conan-gcc13-py3.10` container exists, matching the pattern in xmsgrid/xmscore/xmsinterp); `MATRIX_NAME` and the wheel artifact name now include `-py\${{ matrix.python-version }}` to keep the two Windows builds from colliding.
- Add `[ci] python_versions = ["3.10", "3.13"]` to `build.toml` so a future `xmsconan_ci` regeneration produces the same workflow.

## Test plan
- [ ] CI passes on Mac (3.13), Linux (3.13), Windows (3.10), Windows (3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)