### PR TITLE
Bump xmscore/xmsgrid/xmsinterp and regenerate CI with xmsconan 2.18.0

### DIFF
--- a/.github/workflows/XmsExtractor-CI.yaml
+++ b/.github/workflows/XmsExtractor-CI.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -250,7 +250,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -398,7 +398,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==2.16.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2

--- a/build.toml
+++ b/build.toml
@@ -3,9 +3,9 @@ description = "Extractor library for XMS products"
 ci_type = "github"
 
 xms_dependencies = [
-    { name = "xmscore", version = "7.0.11" },
-    { name = "xmsgrid", version = "9.0.10" },
-    { name = "xmsinterp", version = "7.0.9" },
+    { name = "xmscore", version = "7.0.12" },
+    { name = "xmsgrid", version = "9.0.11" },
+    { name = "xmsinterp", version = "7.0.10" },
 ]
 
 python_namespaced_dir = "extractor"


### PR DESCRIPTION
Fourth library onto the VS2019 bridge, after [xmscore 7.0.12](https://github.com/Aquaveo/xmscore/releases/tag/7.0.12), [xmsgrid 9.0.11](https://github.com/Aquaveo/xmsgrid/releases/tag/9.0.11) and [xmsinterp 7.0.10](https://github.com/Aquaveo/xmsinterp/releases/tag/7.0.10). Seven lines, two coupled changes.

## 1. Dependency bumps — required, not routine

| dependency | from | to |
|---|---|---|
| xmscore | 7.0.11 | **7.0.12** |
| xmsgrid | 9.0.10 | **9.0.11** |
| xmsinterp | 7.0.9 | **7.0.10** |

`xms_dependencies` pins **exact** versions, and **none of the old versions was ever built for msvc 192**. Only 7.0.12 / 9.0.11 / 7.0.10 exist on `aquaveo-vs2019`, so left at the old pins the VS2019 build fails at graph resolution before compiling a single file.

All three are inert for the VS2022 side. Each of those releases contained only its own dependency-and-CI bump — no C++ source change — and each is published on both remotes at a single matching recipe revision (`xmscore c58afa49…`, `xmsgrid 66ac6991…`, `xmsinterp 7fb0a48d…`).

## 2. xmsconan `==2.16.0` → `>=2.18.0`

CI must generate the recipe with the same xmsconan the manual VS2019 track uses. `XmsConan2File.export()` copies `xms_conan2_file.py` into the export folder, so its contents feed the **recipe revision hash**, and 2.18.0 changes that file by 192 lines (the msvc 192 fork). Generating with 2.16.0 in CI and 2.18.0 locally would publish **different rrevs for the same version**.

## Blast radius on the VS2022 side: none

- CI diff is **pins only** — verified by filtering out every xmsconan line.
- No `[vs2019_dependency_overrides]` table, so the generated `conanfile.py` gains no new attribute.
- Regenerated recipe verified: `["xmscore/7.0.12", "xmsgrid/9.0.11", "xmsinterp/7.0.10"]`, `testing_framework = "cxxtest"` (relevant because `gtest/1.17.0` has no msvc 192 build).

Transitive resolution through `aquaveo-vs2019` is already proven three levels deep on xmsinterp, on both the conan graph and the pip graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)