### PR TITLE
Bump xmsgrid to 9.1.0 and xmsinterp to 7.0.11

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -4,8 +4,8 @@ ci_type = "github"
 
 xms_dependencies = [
     { name = "xmscore", version = "7.0.12" },
-    { name = "xmsgrid", version = "9.0.11" },
-    { name = "xmsinterp", version = "7.0.10" },
+    { name = "xmsgrid", version = "9.1.0" },
+    { name = "xmsinterp", version = "7.0.11" },
 ]
 
 python_namespaced_dir = "extractor"


### PR DESCRIPTION
Pins `xmsgrid` at `9.1.0` and `xmsinterp` at `7.0.11` ahead of releasing xmsextractor `10.0.9`. Third library in the chain propagating the xmsgrid 0015785 fix.

## Why

xmsgrid 9.1.0 fixes issue 0015785 (HydroAS arcs snap weirdly): `GmMultiPolyIntersectionSorterTerse` now drops an entry with no matching exit before adjacents are swapped, so `GmMultiPolyIntersector` returns fewer intersections for some inputs. It also adds `GmPtSearch::PtsInBoxInRtree`, a new pure virtual, which is why xmsgrid took a minor bump.

xmsinterp 7.0.11 is the dependency-only release that already picked this up — its full CI passed with no baseline movement.

`xms_dependencies` pins exact versions, so nothing reaches this library without these two edits.

## Availability

Both dependencies are published on **both** conan remotes at matching recipe revisions, so the CI build and the manual msvc 192 build resolve identically:

| dependency | recipe revision | aquaveo-stable | aquaveo-vs2019 |
|---|---|---|---|
| `xmsgrid/9.1.0` | `42868225fabf6e51611e3926221e7a02` | 24 pkgs | 14 pkgs |
| `xmsinterp/7.0.11` | `a96a6a954ffee29ed0eaa056e84c60d0` | 24 pkgs | 14 pkgs |

## Scope

Dependency pins only. No source change. `xmsconan ci` was run and regenerates byte-identical workflows.

**Watch for:** xmsextractor is the most likely library in this chain to feel the intersection change, since extraction runs over grid geometry directly. If its cxxtest baselines move, that is the fix showing up rather than a regression — but it needs a look before merging rather than a blind baseline update. CI will say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)